### PR TITLE
feat: add support for esera air quality sensors

### DIFF
--- a/onewire/owbase.py
+++ b/onewire/owbase.py
@@ -316,7 +316,7 @@ class OwBase(object):
             except Exception:
                 vis = 0
             if vis > 0:
-                keys = {'T': 'temperature', 'H': 'HIH4000/humidity', 'L': 'vis'}
+                keys = {'T': 'temperature', 'H': 'HIH4000/humidity', 'L': 'vis', 'VOC': 'vis'}
             else:
                 keys = {'T': 'temperature', 'H': 'HIH4000/humidity'}
             # check if a voltage from 1-wire bus can be measured
@@ -349,7 +349,7 @@ class OwBase(object):
                 keys['H'] = 'humidity'
                 return keys, typ
             else:
-                self.logger.warning(f"1-Wire: unknown sensor {addr} {typ} page3: {page3}")
+                self.logger.info(f"1-Wire: unknown sensor {addr} {typ} page3: {page3}")
                 keys.update({'V': 'VAD', 'VDD': 'VDD'})
                 return keys, typ
         elif typ == 'DS2401':           # iButton

--- a/onewire/plugin.yaml
+++ b/onewire/plugin.yaml
@@ -265,6 +265,12 @@ item_attributes:
             en: 'Sensor type. See plugin docu for supported types'
             fr: 'Type du capteur. Voir dans documente du plugin pour formats supportés'
 
+    co2_offset:
+        type: num
+        description:
+            de: Offset für die älteren Modelle von Luftgütesensoren der Firma eservice-online (jetzt esera)
+            en: Offset for deprecated models of air quality sensors of company eservice-online (now esera)
+
 item_structs: NONE
   # Definition of item-structure templates for this plugin
 


### PR DESCRIPTION
Read out any co2_offset attribute defined for such sensors and use a different calculation formula. For sensors without any co2_offset defined the implementation should remain unchanged.

Closes #1